### PR TITLE
Add wasm support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,20 +24,3 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
         run: ./gradlew build publish
-
-  publish-mips:
-    needs: publish
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 19
-      - name: Build and publish mips artifacts
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-        run: ./gradlew publishMips

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.0"
+kotlin = "1.9.22"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/kotlin-codepoints-deluxe/build.gradle.kts
+++ b/kotlin-codepoints-deluxe/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
     androidNativeX86()
     androidNativeX64()
 
-    iosArm32()
     iosArm64()
     iosX64()
     iosSimulatorArm64()
@@ -24,28 +23,26 @@ kotlin {
         }
     }
 
-    linuxArm32Hfp()
     linuxArm64()
-    linuxMips32()
-    linuxMipsel32()
     linuxX64()
 
     macosX64()
     macosArm64()
 
     mingwX64()
-    mingwX86()
 
     tvosArm64()
     tvosX64()
     tvosSimulatorArm64()
 
-    wasm32()
+    @Suppress("OPT_IN_USAGE")
+    wasmJs()
+    @Suppress("OPT_IN_USAGE")
+    wasmWasi()
 
     watchosArm32()
     watchosArm64()
     watchosDeviceArm64()
-    watchosX86()
     watchosX64()
     watchosSimulatorArm64()
 
@@ -69,11 +66,4 @@ mavenPublishing {
         name.set("kotlin-codepoint-deluxe")
         description.set("Kotlin Multiplatform (KMP) library that adds a nicer API than kotlin-codepoint for dealing with Unicode code points.")
     }
-}
-
-tasks.create("publishMips") {
-    dependsOn(
-        "publishLinuxMips32PublicationToMavenCentralRepository",
-        "publishLinuxMipsel32PublicationToMavenCentralRepository"
-    )
 }

--- a/kotlin-codepoints/build.gradle.kts
+++ b/kotlin-codepoints/build.gradle.kts
@@ -11,7 +11,6 @@ kotlin {
     androidNativeX86()
     androidNativeX64()
 
-    iosArm32()
     iosArm64()
     iosX64()
     iosSimulatorArm64()
@@ -26,28 +25,26 @@ kotlin {
         }
     }
 
-    linuxArm32Hfp()
     linuxArm64()
-    linuxMips32()
-    linuxMipsel32()
     linuxX64()
 
     macosX64()
     macosArm64()
 
     mingwX64()
-    mingwX86()
 
     tvosArm64()
     tvosX64()
     tvosSimulatorArm64()
 
-    wasm32()
+    @Suppress("OPT_IN_USAGE")
+    wasmJs()
+    @Suppress("OPT_IN_USAGE")
+    wasmWasi()
 
     watchosArm32()
     watchosArm64()
     watchosDeviceArm64()
-    watchosX86()
     watchosX64()
     watchosSimulatorArm64()
 
@@ -77,11 +74,4 @@ mavenPublishing {
         name.set("kotlin-codepoint")
         description.set("Kotlin Multiplatform (KMP) library that adds basic support for Unicode code points.")
     }
-}
-
-tasks.create("publishMips") {
-    dependsOn(
-        "publishLinuxMips32PublicationToMavenCentralRepository",
-        "publishLinuxMipsel32PublicationToMavenCentralRepository"
-    )
 }


### PR DESCRIPTION
Recently Kotlin/Wasm [reached](https://blog.jetbrains.com/kotlin/2023/12/kotlin-for-webassembly-goes-alpha/) alpha status. To add support for it, `wasmJs` target needs to be added. Unfortunately, this target is not available for Kotlin 1.8.0, and upgrading Kotlin compiler [removes](https://blog.jetbrains.com/kotlin/2023/02/update-regarding-kotlin-native-targets/) support for some targets. Previously `wasmJs` target was called `wasm`. I experimented with using `wasm` target instead of `wasmJs` and using kotlin-codepoints from a project compiled for `wasmJs` target, and it seems to work, so this commit adds Kotlin/Wasm support.

If deprecated targets are not important for you, I can make a PR updating Kotlin and removing unsupported architectures.