### PR TITLE
bump versions and apply default hierarchy Template in gradle

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.9.22"
+kotlin = "1.9.24"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-vanniktech-maven-publish = "com.vanniktech.maven.publish:0.23.2"
+vanniktech-maven-publish = "com.vanniktech.maven.publish:0.28.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin-codepoints-deluxe/build.gradle.kts
+++ b/kotlin-codepoints-deluxe/build.gradle.kts
@@ -47,12 +47,12 @@ kotlin {
     watchosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(project(":kotlin-codepoints"))
             }
         }
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(kotlin("test"))
             }

--- a/kotlin-codepoints-deluxe/build.gradle.kts
+++ b/kotlin-codepoints-deluxe/build.gradle.kts
@@ -17,6 +17,10 @@ kotlin {
         browser {}
     }
 
+    wasmJs {
+        browser()
+    }
+
     jvm {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"

--- a/kotlin-codepoints/build.gradle.kts
+++ b/kotlin-codepoints/build.gradle.kts
@@ -19,6 +19,10 @@ kotlin {
         browser {}
     }
 
+    wasmJs {
+        browser()
+    }
+
     jvm {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"

--- a/kotlin-codepoints/build.gradle.kts
+++ b/kotlin-codepoints/build.gradle.kts
@@ -48,16 +48,18 @@ kotlin {
     watchosX64()
     watchosSimulatorArm64()
 
+    applyDefaultHierarchyTemplate()
+
     sourceSets {
-        val commonMain by getting
-        val commonTest by getting {
+        commonMain {}
+        commonTest {
             dependencies {
                 implementation(kotlin("test"))
             }
         }
 
         val commonImplementation by creating {
-            dependsOn(commonMain)
+            dependsOn(commonMain.get())
         }
     }
 


### PR DESCRIPTION
Update project dependencies
- Bump Kotlin to 1.9.24
- Bump Gradle to 8.5
- Bump com.vanniktech.maven.publish to 0.28.0
- Apply default project hierarchy template