### PR TITLE
Change `CodePoint.toString()` to return the string representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- `CodePoint.toString()` now returns the string representation of a code point.
+
+### Added
+- `CodePoint.toUnicodeNotation()` returns the standard Unicode notation of a code point, e.g. `U+1F4E7`. 
+
 ## [0.8.0] - 2024-06-09
 ### Changed
 - Updated to Kotlin 2.0.0

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ to get and idea of what's available.
 val text = "🦕&🦖"
 
 for (codePoint in text.codePointSequence()) {
-    print("code point: $codePoint, char count: ${codePoint.charCount}")
+    print("code point: ${codePoint.toUnicodeNotation()}, char count: ${codePoint.charCount}")
 
     if (codePoint.isBasic) {
         println(" - boring!")

--- a/kotlin-codepoints-deluxe/src/commonMain/kotlin/CodePoint.kt
+++ b/kotlin-codepoints-deluxe/src/commonMain/kotlin/CodePoint.kt
@@ -102,13 +102,22 @@ value class CodePoint internal constructor(val value: Int) {
     }
 
     /**
-     * Returns a string representation of this code point.
+     * Returns the standard Unicode notation of this code point.
      * 
      * "U+" followed by the code point value in hexadecimal (using upper case letters), which is prepended with leading
      * zeros to a minimum of four digits.
      */
-    override fun toString(): String {
+    fun toUnicodeNotation(): String {
         return "U+${value.toString(16).uppercase().padStart(4, '0')}"
+    }
+
+    /**
+     * Returns the string representation of this code point.
+     * 
+     * The returned string consists of the sequence of characters returned by [toChars].
+     */
+    override fun toString(): String {
+        return toChars().concatToString()
     }
 }
 

--- a/kotlin-codepoints-deluxe/src/commonTest/kotlin/CodePointTest.kt
+++ b/kotlin-codepoints-deluxe/src/commonTest/kotlin/CodePointTest.kt
@@ -165,4 +165,19 @@ class CodePointTest {
         }
         assertContentEquals(charArrayOf('z', 'z'), chars)
     }
+
+    @Test
+    fun toUnicodeNotation() {
+        assertEquals("U+0000", 0.toCodePoint().toUnicodeNotation())
+        assertEquals("U+0061", 'a'.toCodePoint().toUnicodeNotation())
+        assertEquals("U+0FFF", 0xFFF.toCodePoint().toUnicodeNotation())
+        assertEquals("U+FFFF", 0xFFFF.toCodePoint().toUnicodeNotation())
+        assertEquals("U+1F995", 0x1F995.toCodePoint().toUnicodeNotation())
+    }
+
+    @Test
+    fun toString_test() {
+        assertEquals("a", 'a'.toCodePoint().toString())
+        assertEquals("\uD83E\uDD95", 0x1F995.toCodePoint().toString())
+    }
 }


### PR DESCRIPTION
Previously `CodePoint.toString()` returned the `U+XXXX` notation. This functionality has been moved to `CodePoint.toUnicodeNotation()`.