### PR TITLE
Add function to create a string from the given code points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - `CodePoint.toUnicodeNotation()` returns the standard Unicode notation of a code point, e.g. `U+1F4E7`. 
 - `CharSequence.codePointCount()` variant without parameters.
+- `CodePoints.toString(…)` creates a string from the given code points.
 
 ## [0.8.0] - 2024-06-09
 ### Changed

--- a/kotlin-codepoints/src/commonMain/kotlin/CodePoints.kt
+++ b/kotlin-codepoints/src/commonMain/kotlin/CodePoints.kt
@@ -88,4 +88,13 @@ expect object CodePoints {
      * `destination[offset]` (high-surrogate) and `destination[offset+1]` (low-surrogate), and 2 is returned.
      */
     fun toChars(codePoint: Int, destination: CharArray, offset: Int): Int
+
+    /**
+     * Converts the given code points to a string.
+     * 
+     * @param codePoints Array of code points.
+     * 
+     * @throws IllegalArgumentException If any invalid code point is found in [codePoints].
+     */
+    fun toString(vararg codePoints: Int): String
 }

--- a/kotlin-codepoints/src/commonTest/kotlin/CodePointsTest.kt
+++ b/kotlin-codepoints/src/commonTest/kotlin/CodePointsTest.kt
@@ -153,4 +153,17 @@ class CodePointsTest {
         }
         assertContentEquals(charArrayOf('z', 'z'), chars)
     }
+
+    @Test
+    fun toString_test() {
+        assertEquals("", CodePoints.toString(*intArrayOf()))
+        assertEquals("a", CodePoints.toString('a'.code))
+        assertEquals("\uD83E\uDD95", CodePoints.toString(0x1F995))
+        assertEquals("\uD83E\uDD95", CodePoints.toString(0xD83E, 0xDD95))
+        assertEquals("a\uD83E\uDD95z", CodePoints.toString('a'.code, 0x1F995, 'z'.code))
+        
+        assertFailsWith<IllegalArgumentException> {  
+            CodePoints.toString('a'.code, 0x110000)
+        }
+    }
 }

--- a/kotlin-codepoints/src/jvmMain/kotlin/CodePoints.kt
+++ b/kotlin-codepoints/src/jvmMain/kotlin/CodePoints.kt
@@ -42,4 +42,8 @@ actual object CodePoints {
     actual inline fun toChars(codePoint: Int, destination: CharArray, offset: Int): Int {
         return Character.toChars(codePoint, destination, offset)
     }
+    
+    actual inline fun toString(vararg codePoints: Int): String {
+        return String(codePoints, offset = 0, length = codePoints.size)
+    }
 }

--- a/kotlin-codepoints/src/nonJvmMain/kotlin/CodePoints.kt
+++ b/kotlin-codepoints/src/nonJvmMain/kotlin/CodePoints.kt
@@ -74,4 +74,15 @@ actual object CodePoints {
 
         this[index] = value
     }
+    
+    actual fun toString(vararg codePoints: Int): String {
+        require(codePoints.all { isValidCodePoint(it) }) { "Array contains at least one invalid code point" }
+        
+        val charCount = codePoints.sumOf { charCount(it) }
+        return buildString(capacity = charCount) {
+            for (codePoint in codePoints) {
+                appendCodePoint(codePoint)
+            }
+        }
+    }
 }


### PR DESCRIPTION
`CodePoints.toString(…)` converts the given code points to a string.

Uses the [`String` constructor](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#String-int:A-int-int-) supporting code points on the JVM; and a `StringBuilder` on all other platforms.