### PR TITLE
Deprecate `CharSequence.codePointIterator(startIndex, endIndex)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Deprecated
+- kotlin-codepoints-deluxe
+  - Deprecated `CharSequence.codePointIterator(startIndex, endIndex)`. Use `CharSequence.subSequence()` instead.
+  - Deprecated `CodePointIterator` constructor. Use `CharSequence.codePointIterator()` to create an instance instead.
+
 ### Changed
 - Updated to Kotlin 2.1.20
 

--- a/kotlin-codepoints-deluxe/src/commonMain/kotlin/CharSequenceExtensions.kt
+++ b/kotlin-codepoints-deluxe/src/commonMain/kotlin/CharSequenceExtensions.kt
@@ -50,8 +50,16 @@ fun CharSequence.codePointSequence(): CodePointSequence {
 /**
  * Iterator for [CodePoint]s in this character sequence.
  */
+fun CharSequence.codePointIterator(): CodePointIterator {
+    return CodePointIterator(this)
+}
+
+@Deprecated(
+    message = "Call codePointIterator() on a sub-sequence instead",
+    replaceWith = ReplaceWith("this.subSequence(startIndex, endIndex).codePointIterator()")
+)
 fun CharSequence.codePointIterator(startIndex: Int = 0, endIndex: Int = length): CodePointIterator {
-    return CodePointIterator(this, startIndex, endIndex)
+    return this.subSequence(startIndex, endIndex).codePointIterator()
 }
 
 /**

--- a/kotlin-codepoints-deluxe/src/commonMain/kotlin/CodePointSequence.kt
+++ b/kotlin-codepoints-deluxe/src/commonMain/kotlin/CodePointSequence.kt
@@ -14,27 +14,23 @@ value class CodePointSequence(private val text: CharSequence) : Sequence<CodePoi
 
 /**
  * Iterator for [CodePoint]s in the given [CharSequence].
- * 
- * The `startIndex` and `endIndex` parameters are the regular `CharSequence` indices, i.e. the number of `Char`s from 
- * the start of the character sequence.
  */
-class CodePointIterator(
-    private val text: CharSequence,
-    startIndex: Int,
-    private val endIndex: Int
-) : Iterator<CodePoint> {
-    private var index = startIndex
-    
+class CodePointIterator internal constructor(private val text: CharSequence) : Iterator<CodePoint> {
+
+    @Deprecated(
+        message = "Call CharSequence.codePointIterator() on a sub-sequence instead",
+        replaceWith = ReplaceWith("text.subSequence(startIndex, endIndex).codePointIterator()"),
+    )
+    constructor(text: CharSequence, startIndex: Int, endIndex: Int) : this(text.subSequence(startIndex, endIndex))
+
+    private var index = 0
+
     override fun hasNext(): Boolean {
-        return index < endIndex
+        return index < text.length
     }
 
     override fun next(): CodePoint {
-        return if (index + 1 == endIndex) {
-            text[index].toCodePoint().also { 
-                index++ 
-            }
-        } else if (hasNext()) {
+        return if (hasNext()) {
             text.codePointAt(index).also { codePoint ->
                 index += codePoint.charCount
             }

--- a/kotlin-codepoints-deluxe/src/commonTest/kotlin/CodePointSequenceTest.kt
+++ b/kotlin-codepoints-deluxe/src/commonTest/kotlin/CodePointSequenceTest.kt
@@ -31,50 +31,8 @@ class CodePointSequenceTest {
     }
 
     @Test
-    fun codePointIterator_with_start_index() {
-        val iterator = "a\uD83E\uDD95b".codePointIterator(startIndex = 1)
-
-        assertTrue(iterator.hasNext())
-        assertEquals("\uD83E\uDD95".codePointAt(0), iterator.next())
-        assertTrue(iterator.hasNext())
-        assertEquals('b'.toCodePoint(), iterator.next())
-        assertFalse(iterator.hasNext())
-        assertFailsWith<IndexOutOfBoundsException> {
-            iterator.next()
-        }
-    }
-
-    @Test
-    fun codePointIterator_with_end_index() {
-        val iterator = "a\uD83E\uDD95b".codePointIterator(endIndex = 3)
-
-        assertTrue(iterator.hasNext())
-        assertEquals('a'.toCodePoint(), iterator.next())
-        assertTrue(iterator.hasNext())
-        assertEquals("\uD83E\uDD95".codePointAt(0), iterator.next())
-        assertFalse(iterator.hasNext())
-        assertFailsWith<IndexOutOfBoundsException> {
-            iterator.next()
-        }
-    }
-
-    @Test
-    fun codePointIterator_with_start_and_end_index() {
-        val iterator = "ab\uD83E\uDD95c".codePointIterator(startIndex = 1, endIndex = 4)
-
-        assertTrue(iterator.hasNext())
-        assertEquals('b'.toCodePoint(), iterator.next())
-        assertTrue(iterator.hasNext())
-        assertEquals("\uD83E\uDD95".codePointAt(0), iterator.next())
-        assertFalse(iterator.hasNext())
-        assertFailsWith<IndexOutOfBoundsException> {
-            iterator.next()
-        }
-    }
-
-    @Test
-    fun codePointIterator_with_start_index_inside_surrogate_pair() {
-        val iterator = "a\uD83E\uDD95b".codePointIterator(startIndex = 2)
+    fun codePointIterator_starting_with_trailing_surrogate() {
+        val iterator = "\uDD95b".codePointIterator()
 
         assertTrue(iterator.hasNext())
         assertEquals('\uDD95'.toCodePoint(), iterator.next())
@@ -87,8 +45,8 @@ class CodePointSequenceTest {
     }
     
     @Test
-    fun codePointIterator_with_end_index_inside_surrogate_pair() {
-        val iterator = "a\uD83E\uDD95b".codePointIterator(endIndex = 2)
+    fun codePointIterator_ending_with_leading_surrogate() {
+        val iterator = "a\uD83E".codePointIterator()
 
         assertTrue(iterator.hasNext())
         assertEquals('a'.toCodePoint(), iterator.next())


### PR DESCRIPTION
Closes #39